### PR TITLE
Multiple Changes:

### DIFF
--- a/Zoo Game/Assets/Scripts/States/Editor/AccountTests.cs
+++ b/Zoo Game/Assets/Scripts/States/Editor/AccountTests.cs
@@ -8,16 +8,14 @@ namespace Zoo.Test
     [TestFixture(Description = "The AccountState contains the player's ZooGame account")]
     public class AccountStateTests : StateTestFixture<AccountState>
     {
-        #region Tests
-
         /// <summary>
         /// Tests that the default values of the account state are set properly
         /// </summary>
         [Test]
         public void TestAccountStateDefaultValues()
         {
-            Assert.NotNull(State.Alias, "The alias should not default to null");
-            Assert.NotNull(State.Email, "The email should not default to null");
+            Assert.IsEmpty(State.Alias);
+            Assert.IsEmpty(State.Email);
         }
 
         /// <summary>
@@ -26,20 +24,24 @@ namespace Zoo.Test
         [Test]
         public void TestSetAccountData()
         {
-            var alias = "TestAlias";
-            var email = "test@test.com";
+            var prevAlias = State.Alias;
+            var prevEmail = State.Email;
+
+            var alias = prevAlias + "_Test";
+            var email = prevEmail + "_Test";
 
             ExecuteStrictAndUpdate(AccountEvents.SetAccountData, alias, email);
 
-            Assert.AreEqual(alias, State.Alias, "SetAccountData did not update the state's alias");
-            Assert.AreEqual(email, State.Email, "SetAccountData did not update the state's email");
+            Assert.AreNotEqual(prevAlias, State.Alias);
+            Assert.AreEqual(alias, State.Alias);
+
+            Assert.AreNotEqual(prevEmail, State.Email);
+            Assert.AreEqual(email, State.Email);
 
             var copy = MakeCopy();
 
-            Assert.AreEqual(State.Alias, copy.Alias, "Copies of the state do not have the same alias after a SetAccountData event");
-            Assert.AreEqual(State.Email, copy.Email, "Copies of the state do not have the same email after a SetAccountData event");
+            Assert.AreEqual(State.Alias, copy.Alias);
+            Assert.AreEqual(State.Email, copy.Email);
         }
-
-        #endregion
     }
 }

--- a/Zoo Game/Assets/Scripts/States/Editor/HUDTests.cs
+++ b/Zoo Game/Assets/Scripts/States/Editor/HUDTests.cs
@@ -14,8 +14,8 @@ namespace Zoo.Test
         [Test]
         public void TestDefaultData()
         {
-            Assert.IsFalse(State.Visible, "State should default to not visible");
-            Assert.IsFalse(State.RotateEnabled, "State should default to rotate disabled");
+            Assert.IsFalse(State.Visible);
+            Assert.IsFalse(State.RotateEnabled);
         }
 
         /// <summary>
@@ -24,7 +24,7 @@ namespace Zoo.Test
         [Test]
         public void TestDependenciesUsed()
         {
-            Assert.NotNull(GetState<UIState>(), "UI State, which is a dependency, is not being used");
+            Assert.NotNull(GetState<UIState>());
         }
 
         /// <summary>
@@ -36,11 +36,13 @@ namespace Zoo.Test
             var start = State.RotateEnabled;
 
             ExecuteAndUpdate(HUDEvents.ToggleMovementMode);
-            Assert.AreNotEqual(start, State.RotateEnabled, "ToggleMovementMode is not toggling the movement mode");
-            Assert.AreEqual(State.RotateEnabled, MakeCopy().RotateEnabled, "Copies do not have the same rotate enabled after a ToggleMovementMode event");
+
+            Assert.AreNotEqual(start, State.RotateEnabled);
+            var copy = MakeCopy();
+            Assert.AreEqual(State.RotateEnabled, copy.RotateEnabled);
 
             ExecuteAndUpdate(HUDEvents.ToggleMovementMode);
-            Assert.AreEqual(start, State.RotateEnabled, "ToggleMovementMode does not end at its starting value after two executions");
+            Assert.AreEqual(start, State.RotateEnabled);
         }
 
         /// <summary>
@@ -50,10 +52,10 @@ namespace Zoo.Test
         public void TestSetHUDOpen()
         {
             ExecuteAndUpdate(UIEvents.SetHUDOpen);
-            Assert.True(State.Visible, "SetHUDOpen from the UI state is not making the HUD visible");
+            Assert.True(State.Visible);
 
             ExecuteAndUpdate(UIEvents.SetZooCreationOpen);
-            Assert.False(State.Visible, "Opening a different view in the UI is not making the HUD invisible");
+            Assert.False(State.Visible);
         }
     }
 }

--- a/Zoo Game/Assets/Scripts/States/Editor/LogInTests.cs
+++ b/Zoo Game/Assets/Scripts/States/Editor/LogInTests.cs
@@ -32,7 +32,9 @@ namespace Zoo.Test
 
             Assert.AreNotEqual(prev, State.Email);
             Assert.AreEqual(expected, State.Email);
-            Assert.AreEqual(State.Email, MakeCopy().Email);
+
+            var copy = MakeCopy();
+            Assert.AreEqual(State.Email, copy.Email);
         }
 
         /// <summary>
@@ -48,7 +50,9 @@ namespace Zoo.Test
 
             Assert.AreNotEqual(prev, State.Password);
             Assert.AreEqual(expected, State.Password);
-            Assert.AreEqual(State.Password, MakeCopy().Password);
+
+            var copy = MakeCopy();
+            Assert.AreEqual(State.Password, copy.Password);
         }
 
         /// <summary>
@@ -60,7 +64,9 @@ namespace Zoo.Test
             ExecuteStrictAndUpdate(LogInEvents.Submit);
 
             Assert.IsTrue(State.Submitted);
-            Assert.AreEqual(State.Submitted, MakeCopy().Submitted);
+
+            var copy = MakeCopy();
+            Assert.AreEqual(State.Submitted, copy.Submitted);
         }
 
         /// <summary>

--- a/Zoo Game/Assets/Scripts/States/Editor/MainMenuTests.cs
+++ b/Zoo Game/Assets/Scripts/States/Editor/MainMenuTests.cs
@@ -14,10 +14,10 @@ namespace Zoo.Test
         [Test]
         public void TestMainMenuDefaultValues()
         {
-            Assert.AreEqual("", State.SelectedMap, "The selected map should be initialized to empty");
-            Assert.AreEqual("", State.SelectedPlayMode, "The selected play mode should initialized to empty");
-            Assert.AreEqual(State.OpenPanel, MainMenuState.MainMenu, "The open panel should default to the main menu");
-            Assert.IsFalse(State.Submitted, "The submitted flag should be initialized to false");
+            Assert.IsEmpty(State.SelectedMap);
+            Assert.IsEmpty(State.SelectedPlayMode);
+            Assert.AreEqual(State.OpenPanel, MainMenuState.MainMenu);
+            Assert.IsFalse(State.Submitted);
         }
 
         /// <summary>
@@ -27,10 +27,10 @@ namespace Zoo.Test
         public void TestOpenPlayModeMenu()
         {
             ExecuteStrictAndUpdate(MainMenuEvents.OpenPlayModeMenu);
-            Assert.AreEqual(MainMenuState.PlayModeSelection, State.OpenPanel, "OpenPlayModeMenu is not transitioning to the correct panel");
+            Assert.AreEqual(MainMenuState.PlayModeSelection, State.OpenPanel);
 
             var copy = MakeCopy();
-            Assert.AreEqual(State.OpenPanel, copy.OpenPanel, "Copies do not have the same OpenPanel after the OpenPlayModeMenu event");
+            Assert.AreEqual(State.OpenPanel, copy.OpenPanel);
         }
 
         /// <summary>
@@ -43,10 +43,10 @@ namespace Zoo.Test
             ExecuteStrictAndUpdate(MainMenuEvents.OpenPlayModeMenu);
             ExecuteStrictAndUpdate(MainMenuEvents.ReturnToMain);
 
-            Assert.AreEqual(MainMenuState.MainMenu, State.OpenPanel, "ReturnToMain is not transitioning to the correct panel");
+            Assert.AreEqual(MainMenuState.MainMenu, State.OpenPanel);
 
             var copy = MakeCopy();
-            Assert.AreEqual(State.OpenPanel, copy.OpenPanel, "Copies do not have the same OpenPanel after the ReturnToMain event");
+            Assert.AreEqual(State.OpenPanel, copy.OpenPanel);
         }
 
         /// <summary>
@@ -60,11 +60,11 @@ namespace Zoo.Test
 
             ExecuteStrictAndUpdate(MainMenuEvents.SelectMap, expected);
 
-            Assert.AreNotEqual(previous, State.SelectedMap, "SelectMap is not changing the selected map");
-            Assert.AreEqual(expected, State.SelectedMap, "SelectMap is not changing to the provided value");
+            Assert.AreNotEqual(previous, State.SelectedMap);
+            Assert.AreEqual(expected, State.SelectedMap);
 
             var copy = MakeCopy();
-            Assert.AreEqual(State.SelectedMap, copy.SelectedMap, "Copies do not have the same SelectedMap after the SelectMap event");
+            Assert.AreEqual(State.SelectedMap, copy.SelectedMap);
         }
 
         /// <summary>
@@ -74,12 +74,12 @@ namespace Zoo.Test
         public void TestSelectFreePlayMode()
         {
             ExecuteStrictAndUpdate(PlayModeEvents.SelectFreePlay);
-            Assert.AreEqual(MainMenuState.FreePlay, State.SelectedPlayMode, "SelectFreePlay does not change the state to free play mode");
-            Assert.AreEqual(MainMenuState.MapSelection, State.OpenPanel, "SelectFreePlay does not change the open panel to map selection");
+            Assert.AreEqual(MainMenuState.FreePlay, State.SelectedPlayMode);
+            Assert.AreEqual(MainMenuState.MapSelection, State.OpenPanel);
 
             var copy = MakeCopy();
-            Assert.AreEqual(State.SelectedPlayMode, copy.SelectedPlayMode, "Copies do not have the same SelectedPlayMode after the SelectFreePlay event");
-            Assert.AreEqual(State.SelectedMap, copy.SelectedMap, "Copies do not have the same SelectedMap after the SelectFreePlay event");
+            Assert.AreEqual(State.SelectedPlayMode, copy.SelectedPlayMode);
+            Assert.AreEqual(State.SelectedMap, copy.SelectedMap);
         }
 
         /// <summary>
@@ -92,12 +92,12 @@ namespace Zoo.Test
             ExecuteStrictAndUpdate(PlayModeEvents.SelectFreePlay);
             ExecuteStrictAndUpdate(PlayModeEvents.UndoPlayModeSelection);
 
-            Assert.AreEqual("", State.SelectedPlayMode, "UndoPlayModeSelection does not clear the play mode data");
-            Assert.AreEqual(MainMenuState.PlayModeSelection, State.OpenPanel, "UndoPlayModeSelection does not change the open panel to play mode selection");
+            Assert.AreEqual("", State.SelectedPlayMode);
+            Assert.AreEqual(MainMenuState.PlayModeSelection, State.OpenPanel);
 
             var copy = MakeCopy();
-            Assert.AreEqual(State.SelectedPlayMode, copy.SelectedPlayMode, "Copies do not have the same SelectedPlayMode after the UndoPlayModeSelection event");
-            Assert.AreEqual(State.SelectedMap, copy.SelectedMap, "Copies do not have the same SelectedMap after the UndoPlayModeSelection event");
+            Assert.AreEqual(State.SelectedPlayMode, copy.SelectedPlayMode);
+            Assert.AreEqual(State.SelectedMap, copy.SelectedMap);
         }
 
         /// <summary>
@@ -107,10 +107,10 @@ namespace Zoo.Test
         public void TestSubmitSelections()
         {
             ExecuteStrictAndUpdate(MainMenuEvents.SubmitSelections);
-            Assert.IsTrue(State.Submitted, "SubmitSelections is not setting the submitted flag to true");
+            Assert.IsTrue(State.Submitted);
 
             var copy = MakeCopy();
-            Assert.AreEqual(State.Submitted, copy.Submitted, "Copies do not have the same submitted flag after SubmitSelections");
+            Assert.AreEqual(State.Submitted, copy.Submitted);
         }
 
         /// <summary>
@@ -126,17 +126,17 @@ namespace Zoo.Test
 
             ExecuteStrictAndUpdate(MainMenuEvents.ResetSelections);
 
-            Assert.AreEqual("", State.SelectedMap, "The selected map should be reset to empty");
-            Assert.AreEqual("", State.SelectedPlayMode, "The selected play mode should reset to empty");
-            Assert.AreEqual(State.OpenPanel, MainMenuState.MainMenu, "The open panel should reset to the main menu");
-            Assert.IsFalse(State.Submitted, "The submitted flag should be reset to false");
+            Assert.AreEqual("", State.SelectedMap);
+            Assert.AreEqual("", State.SelectedPlayMode);
+            Assert.AreEqual(State.OpenPanel, MainMenuState.MainMenu);
+            Assert.IsFalse(State.Submitted);
 
             var copy = MakeCopy();
 
-            Assert.AreEqual(State.SelectedMap, copy.SelectedMap, "Copies do not have the same SelectedMap after the ResetSelections event");
-            Assert.AreEqual(State.SelectedPlayMode, copy.SelectedPlayMode, "Copies do not have the same SelectedPlayMode after the ResetSelections event");
-            Assert.AreEqual(State.OpenPanel, copy.OpenPanel, "Copies do not have the same OpenPanel after the ResetSelections event");
-            Assert.AreEqual(State.Submitted, copy.Submitted, "Copies do not have the same Submitted flag after the ResetSelections event");
+            Assert.AreEqual(State.SelectedMap, copy.SelectedMap);
+            Assert.AreEqual(State.SelectedPlayMode, copy.SelectedPlayMode);
+            Assert.AreEqual(State.OpenPanel, copy.OpenPanel);
+            Assert.AreEqual(State.Submitted, copy.Submitted);
         }
     }
 }

--- a/Zoo Game/Assets/Scripts/States/Editor/UITests.cs
+++ b/Zoo Game/Assets/Scripts/States/Editor/UITests.cs
@@ -16,7 +16,7 @@ namespace Zoo.Test
         [Test]
         public void TestUIDefaultValues()
         {
-            Assert.AreEqual("", State.OpenPanel, "The open panel should default to empty");
+            Assert.IsEmpty(State.OpenPanel);
         }
 
         /// <summary>
@@ -26,10 +26,10 @@ namespace Zoo.Test
         public void TestSetHUDOpen()
         {
             ExecuteStrictAndUpdate(UIEvents.SetHUDOpen);       
-            Assert.AreEqual(UIState.HUD, State.OpenPanel, "SetHUDOpen is not setting the open panel to the HUD");
+            Assert.AreEqual(UIState.HUD, State.OpenPanel);
 
             var copy = MakeCopy();
-            Assert.AreEqual(State.OpenPanel, copy.OpenPanel, "Copies do not have the same open panel after the SetHUDOpen event");
+            Assert.AreEqual(State.OpenPanel, copy.OpenPanel);
         }
 
         /// <summary>
@@ -39,10 +39,10 @@ namespace Zoo.Test
         public void TestSetZooCreationOpen()
         {
             ExecuteStrictAndUpdate(UIEvents.SetZooCreationOpen);
-            Assert.AreEqual(UIState.ZooCreation, State.OpenPanel, "SetZooCreationOpen is not setting the open panel to the ZooCreation");
+            Assert.AreEqual(UIState.ZooCreation, State.OpenPanel);
 
             var copy = MakeCopy();
-            Assert.AreEqual(State.OpenPanel, copy.OpenPanel, "Copies do not have the same open panel after the SetZooCreationOpen event");
+            Assert.AreEqual(State.OpenPanel, copy.OpenPanel);
         }
 
         #endregion

--- a/Zoo Game/Assets/Scripts/States/Editor/ZooCreationTests.cs
+++ b/Zoo Game/Assets/Scripts/States/Editor/ZooCreationTests.cs
@@ -14,9 +14,9 @@ namespace Zoo.Test
         [Test]
         public void TestDefaultData()
         {
-            Assert.AreEqual("", State.NameText, "NameText should be initialized as empty");
-            Assert.IsFalse(State.Visible, "The state should not be visible by default");
-            Assert.IsFalse(State.Submitted, "The submission flag should be disabled by default");
+            Assert.IsEmpty(State.NameText);
+            Assert.IsFalse(State.Visible);
+            Assert.IsFalse(State.Submitted);
         }
 
         /// <summary>
@@ -25,7 +25,7 @@ namespace Zoo.Test
         [Test]
         public void TestDependenciesUsed()
         {
-            Assert.NotNull(GetState<UIState>(), "UI State, which is a dependency, is not being used");
+            Assert.NotNull(GetState<UIState>());
         }
 
         /// <summary>
@@ -39,9 +39,11 @@ namespace Zoo.Test
 
             ExecuteStrictAndUpdate(ZooCreationEvents.SetNameText, expected);
 
-            Assert.AreNotEqual(original, State.NameText, "SetNameText is not changing NameText");
-            Assert.AreEqual(expected, State.NameText, "SetNameText is not changing the name text to the provided value");
-            Assert.AreEqual(State.NameText, MakeCopy().NameText, "Copies do not have the same name text after a SetNameText event");
+            Assert.AreNotEqual(original, State.NameText);
+            Assert.AreEqual(expected, State.NameText);
+
+            var copy = MakeCopy();
+            Assert.AreEqual(State.NameText, copy.NameText);
         }
 
         /// <summary>
@@ -52,8 +54,10 @@ namespace Zoo.Test
         {
             ExecuteStrictAndUpdate(ZooCreationEvents.Submit);
 
-            Assert.IsTrue(State.Submitted, "Submit is not enabling the submitted flag");
-            Assert.AreEqual(State.Submitted, MakeCopy().Submitted, "Copies do not have the same submitted flag");
+            Assert.IsTrue(State.Submitted);
+
+            var copy = MakeCopy();
+            Assert.AreEqual(State.Submitted, copy.Submitted);
         }
 
         /// <summary>
@@ -67,12 +71,12 @@ namespace Zoo.Test
             ExecuteStrictAndUpdate(ZooCreationEvents.Submit);
             ExecuteStrictAndUpdate(ZooCreationEvents.Reset);
 
-            Assert.AreEqual("", State.NameText, "NameText should be empty after a reset");
-            Assert.IsFalse(State.Submitted, "The submission flag should be disabled after a reset");
+            Assert.AreEqual("", State.NameText);
+            Assert.IsFalse(State.Submitted);
 
             var copy = MakeCopy();
-            Assert.AreEqual(State.NameText, copy.NameText, "Copies do not have the same name text after a reset");
-            Assert.AreEqual(State.Submitted, copy.Submitted, "Copies do not have the same submission flag after a reset");
+            Assert.AreEqual(State.NameText, copy.NameText);
+            Assert.AreEqual(State.Submitted, copy.Submitted);
         }
 
         /// <summary>
@@ -85,13 +89,13 @@ namespace Zoo.Test
             var previous = State.Visible;
             ExecuteStrictAndUpdate(ZooCreationEvents.Reset);
 
-            Assert.AreEqual(previous, State.Visible, "Reset is changing the visibility flag when the view should be hidden");
+            Assert.AreEqual(previous, State.Visible);
 
             ExecuteStrictAndUpdate(UIEvents.SetZooCreationOpen);
             previous = State.Visible;
             ExecuteStrictAndUpdate(ZooCreationEvents.Reset);
 
-            Assert.AreEqual(previous, State.Visible, "Reset is changing the visibility flag when the view should be visible");
+            Assert.AreEqual(previous, State.Visible);
         }
 
         /// <summary>
@@ -101,10 +105,10 @@ namespace Zoo.Test
         public void TestSetZooCreationOpen()
         {
             ExecuteStrictAndUpdate(UIEvents.SetZooCreationOpen);
-            Assert.True(State.Visible, "SetZooCreationOpen from the UI state is not making Zoo Creation visible");
+            Assert.True(State.Visible);
 
             ExecuteStrictAndUpdate(UIEvents.SetHUDOpen);
-            Assert.False(State.Visible, "Opening a different view in the UI is not making Zoo Creation invisible");
+            Assert.False(State.Visible);
         }
     }
 }


### PR DESCRIPTION
Removed any inline MakeCopy() statements. These will make test extension more difficult later when more data is affected
Removed all error messages. TestRunner does not seem to use them and they bloat the code more than is necessary
Changed equality assertions with empty strings to AreEmpty statements.